### PR TITLE
v0.5.5

### DIFF
--- a/lib/rsruby.rb
+++ b/lib/rsruby.rb
@@ -87,6 +87,13 @@ class RSRuby
     @@underscore_translation = !!tf
   end
 
+  def underscore_translation
+    self.class.underscore_translation
+  end
+  def underscore_translation=(tf)
+    self.class.underscore_translation = tf
+  end
+
   #Create a new RSRuby interpreter instance. The Singleton design pattern
   #ensures that only one instance can be running in a script. Further
   #calls to RSRuby.instance will return the original instance.
@@ -197,7 +204,7 @@ class RSRuby
   #String with the real R name according to the rules given in the manual.
   def RSRuby.convert_method_name(name)
 
-    return name if !@@underscore_translation
+    return name if !@@underscore_translation   # must access class var, else you get a Singleton-related recursive error
 
     if name.length > 1 and name[-1].chr == '_' and name[-2].chr != '_'
       name = name[0..-2]
@@ -252,10 +259,10 @@ class RSRuby
   def RSRuby.with_default_mode(mode)
     original_mode = get_default_mode
     begin
-      RSRuby.instance.set_default_mode(mode)
+      RSRuby.set_default_mode(mode)
       yield
     ensure
-      RSRuby.instance.set_default_mode(original_mode)
+      RSRuby.set_default_mode(original_mode)
     end
   end
 

--- a/lib/rsruby.rb
+++ b/lib/rsruby.rb
@@ -79,12 +79,12 @@ class RSRuby
     @@r_flags = r_flags
   end
 
-  @@disable_underscore_translation = false
-  def self.disable_underscore_translation
-    @@disable_underscore_translation
+  @@underscore_translation = true
+  def self.underscore_translation
+    @@underscore_translation
   end
-  def self.disable_underscore_translation=(tf)
-    @@disable_underscore_translation = !!tf
+  def self.underscore_translation=(tf)
+    @@underscore_translation = !!tf
   end
 
   #Create a new RSRuby interpreter instance. The Singleton design pattern
@@ -197,7 +197,7 @@ class RSRuby
   #String with the real R name according to the rules given in the manual.
   def RSRuby.convert_method_name(name)
 
-    return name if @@disable_underscore_translation
+    return name if !@@underscore_translation
 
     if name.length > 1 and name[-1].chr == '_' and name[-2].chr != '_'
       name = name[0..-2]

--- a/lib/rsruby.rb
+++ b/lib/rsruby.rb
@@ -54,7 +54,7 @@ require 'complex'
 
 class RSRuby
 
-  VERSION = '0.5.4'
+  VERSION = '0.5.5'
 
   include Singleton
 
@@ -67,6 +67,8 @@ class RSRuby
   NO_CONVERSION = 0
   NO_DEFAULT = -1
 
+  VALID_CONVERSION_MODES = [-1, 0, 1, 2, 3, 4]
+
   attr_accessor :proc_table, :class_table, :default_mode, :caching
 
   @@r_flags = ["--quiet", "--vanilla"]
@@ -75,6 +77,14 @@ class RSRuby
   end
   def self.r_flags= r_flags
     @@r_flags = r_flags
+  end
+
+  @@disable_underscore_translation = false
+  def self.disable_underscore_translation
+    @@disable_underscore_translation
+  end
+  def self.disable_underscore_translation=(tf)
+    @@disable_underscore_translation = tf
   end
 
   #Create a new RSRuby interpreter instance. The Singleton design pattern
@@ -224,20 +234,27 @@ class RSRuby
 
   end
 
-  #Sets the default conversion mode for RSRuby. The constants defined
-  #in #RSRuby should be used
-  #DEPRECATED: Use the accessor instead
-  def RSRuby.set_default_mode(m)
-    if m < -1 or m > TOP_CONVERSION
-      raise ArgumentError, "Invalid mode requested"
-    end
-    RSRuby.instance.default_mode = m
+  # Sets the default conversion mode for RSRuby.
+
+  def RSRuby.set_default_mode(mode)
+    raise ArgumentError, "Invalid mode requested" if !VALID_CONVERSION_MODES.include?(mode)
+    RSRuby.instance.default_mode = mode
   end
-  #Returns the current default conversion mode as an Integer.
-  #DEPRECATED: Use the accessor on the RSRuby instance isntead
+
   def RSRuby.get_default_mode
     RSRuby.instance.default_mode
   end
+
+  def RSRuby.with_default_mode(mode)
+    original_mode = get_default_mode
+    begin
+      RSRuby.instance.set_default_mode(mode)
+      yield
+    ensure
+      RSRuby.instance.set_default_mode(original_mode)
+    end
+  end
+
 
   #TODO - not implemented
   def RSRuby.set_rsruby_input(m)

--- a/lib/rsruby.rb
+++ b/lib/rsruby.rb
@@ -84,7 +84,7 @@ class RSRuby
     @@disable_underscore_translation
   end
   def self.disable_underscore_translation=(tf)
-    @@disable_underscore_translation = tf
+    @@disable_underscore_translation = !!tf
   end
 
   #Create a new RSRuby interpreter instance. The Singleton design pattern
@@ -196,6 +196,9 @@ class RSRuby
   #Converts a String representing a 'Ruby-style' R function name into a
   #String with the real R name according to the rules given in the manual.
   def RSRuby.convert_method_name(name)
+
+    return name if @@disable_underscore_translation
+
     if name.length > 1 and name[-1].chr == '_' and name[-2].chr != '_'
       name = name[0..-2]
     end
@@ -203,7 +206,8 @@ class RSRuby
     name = name.gsub(/([^\\])_/, '\1.')
     name = name.gsub(/^_/, '.')
     name = name.gsub(/\\_/, '_')
-    return name
+    name
+
   end
 
   #Converts an Array of function arguments into lcall format. If the last

--- a/rsruby.gemspec
+++ b/rsruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{rsruby}
-  s.version = "0.5.4"
+  s.version = "0.5.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Alex Gutteridge"]

--- a/test/tc_underscore_translation.rb
+++ b/test/tc_underscore_translation.rb
@@ -1,0 +1,16 @@
+require 'test/unit'
+require 'rsruby'
+
+class TestUnderscoreTranslation < Test::Unit::TestCase
+  def setup
+    @r = RSRuby.instance
+  end
+
+  def test_underscore_translation
+    assert(@r.underscore_translation)
+    assert_raise RException do @r.send("seq_len", {"length.out" => 10}) end
+    @r.underscore_translation = false
+    assert_nothing_raised { @r.send("seq_len", {"length.out" => 10}) }
+  end
+
+end


### PR DESCRIPTION
- New underscore_translation setting, if it's false then we don't convert underscores, and you should use `send` to call methods with dots in their names. 
- Added `RSRuby.with_default_mode`. 
