### PR TITLE
Fix typo PROTECr => PROTECT

### DIFF
--- a/ext/Converters.c
+++ b/ext/Converters.c
@@ -56,14 +56,14 @@ SEXP ruby_to_R(VALUE obj)
     return R_NilValue;
   }
 
-  //If object has 'as_r' then call it and use 
+  //If object has 'as_r' then call it and use
   //returned value subsequently
   if (rb_respond_to(obj, rb_intern("as_r"))){
     obj = rb_funcall(obj,rb_intern("as_r"),0);
     if (!obj)
       return NULL;
   }
-  
+
   if (Robj_Check(obj))
     {
       Data_Get_Struct(obj, struct SEXPREC, robj);
@@ -77,9 +77,9 @@ SEXP ruby_to_R(VALUE obj)
       } else {
 	LOGICAL_DATA(robj)[0] = FALSE;
       }
-	  
+
     }
-  else if (TYPE(obj) == T_FIXNUM || 
+  else if (TYPE(obj) == T_FIXNUM ||
 	   TYPE(obj) == T_BIGNUM)
     {
       PROTECT(robj = NEW_INTEGER(1));
@@ -90,26 +90,26 @@ SEXP ruby_to_R(VALUE obj)
       PROTECT(robj = NEW_NUMERIC(1));
       NUMERIC_DATA(robj)[0] = NUM2DBL(obj);
     }
-  else if (RubyComplex_Check(obj)) 
+  else if (RubyComplex_Check(obj))
     {
       PROTECT(robj = NEW_COMPLEX(1));
       COMPLEX_DATA(robj)[0].r = NUM2DBL(rb_funcall(obj,rb_intern("real"),0));
       COMPLEX_DATA(robj)[0].i = NUM2DBL(rb_funcall(obj,rb_intern("image"),0));
     }
-  else if (!NIL_P(rb_check_string_type(obj))) 
+  else if (!NIL_P(rb_check_string_type(obj)))
     {
       PROTECT(robj = NEW_STRING(1));
       SET_STRING_ELT(robj, 0, COPY_TO_USER_STRING(RSTRING_PTR(obj)));
     }
-  else if (!NIL_P(rb_check_array_type(obj))) 
+  else if (!NIL_P(rb_check_array_type(obj)))
     {
       PROTECT(robj = array_to_R(obj));
     }
-  else if (TYPE(obj) == T_HASH) 
+  else if (TYPE(obj) == T_HASH)
     {
       PROTECT(robj = hash_to_R(obj));
     }
-  else 
+  else
     {
       str = rb_funcall(obj,rb_intern("inspect"),0);
       str = rb_funcall(str,rb_intern("slice"),2,INT2NUM(0),INT2NUM(60));
@@ -118,7 +118,7 @@ SEXP ruby_to_R(VALUE obj)
       errobj = rb_exc_new2(rb_eArgError, buf);
       rb_exc_raise(errobj);
 
-      PROTECr(robj = NULL);       /* Protected to avoid stack inbalance */
+      PROTECT(robj = NULL);       /* Protected to avoid stack inbalance */
     }
 
   UNPROTECT(1);
@@ -134,7 +134,7 @@ SEXP array_to_R(VALUE obj)
 
   /* This matrix defines what mode a vector should take given what
      it already contains and a new item
-  
+
      E.g. Row 0 indicates that if we've seen an any, the vector will
      always remain an any.  Row 3 indicates that if we've seen a
      float, then seeing an boolean, integer, or float will preserve
@@ -150,7 +150,7 @@ SEXP array_to_R(VALUE obj)
     {0, 0, 0, 0, 0, 5, 0}, // string
     {0, 0, 0, 0, 0, 0, 6}  // RObj
   };
-  
+
   //Probably unnessecary but just in case
   obj = rb_check_array_type(obj);
 
@@ -171,7 +171,7 @@ SEXP array_to_R(VALUE obj)
 
     if (!(rit = ruby_to_R(it)))
       goto exception;
-    
+
     SET_VECTOR_ELT(robj, i, rit);
   }
 
@@ -220,7 +220,7 @@ hash_to_R(VALUE obj)
     return NULL;
   if (!(values = rb_funcall(obj,rb_intern("values"),0)))
     return NULL;
-  
+
   if (!(robj  = array_to_R(values)))
     goto fail;
   if (!(names = array_to_R(keys)))
@@ -241,7 +241,7 @@ type_to_int(VALUE obj)
 {
   if (obj == Qtrue || obj == Qfalse)
     return BOOL_T;
-  else if (TYPE(obj) == T_FIXNUM || 
+  else if (TYPE(obj) == T_FIXNUM ||
 	   TYPE(obj) == T_BIGNUM)
     return INT_T;
   else if (TYPE(obj) == T_FLOAT)
@@ -285,7 +285,7 @@ VALUE to_ruby_with_mode(SEXP robj, int mode)
       if (i==1) break;
     default:
       protect_robj(robj);
-      obj = Data_Wrap_Struct(rb_const_get(rb_cObject, 
+      obj = Data_Wrap_Struct(rb_const_get(rb_cObject,
 					  rb_intern("RObj")), 0,  &Robj_dealloc, robj);
       rb_iv_set(obj,"@conversion",INT2FIX(TOP_MODE));
       rb_iv_set(obj,"@wrap",Qfalse);
@@ -339,7 +339,7 @@ to_ruby_vector(SEXP robj, VALUE *obj, int mode)
   len = GET_LENGTH(robj);
   tmp = rb_ary_new2(len);
   type = TYPEOF(robj);
-  
+
   for (i=0; i<len; i++) {
     switch (type)
       {
@@ -451,11 +451,11 @@ from_proc_table(SEXP robj, VALUE *fun)
   funs  = rb_funcall(proc_table,rb_intern("values"),0);
   l     = FIX2INT(rb_funcall(proc_table,rb_intern("size"),0));
 
-  obj = Data_Wrap_Struct(rb_const_get(rb_cObject, 
+  obj = Data_Wrap_Struct(rb_const_get(rb_cObject,
 				      rb_intern("RObj")), 0,  &Robj_dealloc, robj);
   rb_iv_set(obj,"@conversion",INT2FIX(TOP_MODE));
   rb_iv_set(obj,"@wrap",Qfalse);
-  
+
   error = 0;
   for (i=0; i<l; i++) {
     proc = rb_ary_entry(procs, i);
@@ -488,7 +488,7 @@ VALUE reset_mode(VALUE mode){
 
   rb_iv_set(RSRUBY,
 	    "@default_mode",
-	    mode); 
+	    mode);
 
   return Qnil;
 
@@ -514,7 +514,7 @@ to_ruby_proc(SEXP robj, VALUE *obj)
 
   //Create new object based on robj and call the function
   //found above with it as argument
-  tmp = Data_Wrap_Struct(rb_const_get(rb_cObject, 
+  tmp = Data_Wrap_Struct(rb_const_get(rb_cObject,
 				      rb_intern("RObj")), 0,  &Robj_dealloc, robj);
   rb_iv_set(tmp,"@conversion",INT2FIX(TOP_MODE));
   rb_iv_set(tmp,"@wrap",Qfalse);
@@ -576,13 +576,13 @@ to_ruby_class(SEXP robj, VALUE *obj)
   VALUE args[2];
 
   fun = from_class_table(robj);
-  
+
   if (fun==Qnil)
     return 0;                   /* conversion failed */
-  
-  tmp = Data_Wrap_Struct(rb_const_get(rb_cObject, 
+
+  tmp = Data_Wrap_Struct(rb_const_get(rb_cObject,
 				      rb_intern("RObj")), 0,  &Robj_dealloc, robj);
-  rb_iv_set(tmp,"@conversion",INT2FIX(TOP_MODE));  
+  rb_iv_set(tmp,"@conversion",INT2FIX(TOP_MODE));
   rb_iv_set(tmp,"@wrap",Qfalse);
 
   //Again set conversion mode to basic to prevent recursion
@@ -614,7 +614,7 @@ VALUE to_ruby_hash(VALUE obj, SEXP names)
     name = CHAR(STRING_ELT(names, i));
     rb_hash_aset(hash, rb_external_str_new_cstr(name), it);
   }
-  
+
   return hash;
 }
 
@@ -633,7 +633,7 @@ VALUE ltranspose(VALUE list, int *dims, int *strides,
     for (i=0; i<dims[pos]; i++) {
       if (!(it = rb_ary_entry(list, i*strides[pos]+shift)))
         return Qnil;
-      rb_ary_store(nl, i, it);     
+      rb_ary_store(nl, i, it);
     }
     return nl;
   }
@@ -647,7 +647,7 @@ VALUE ltranspose(VALUE list, int *dims, int *strides,
 
   return nl;
 }
-      
+
 /* Convert a R Array to a Ruby Array (in the form of
  * array of arrays of ...) */
 VALUE to_ruby_array(VALUE obj, SEXP robj)


### PR DESCRIPTION
I think this was accidentally introduced in 39c788799d3fd53c1266206490fbdd56743a6918. I believe it hasn't caused problems because if we're in this part of the code we are raising a Ruby exception anyway (`rb_exc_raise`).

If you try to build this with

    -Werror,-Wimplicit-function-declaration

then you get an error

    error: implicit declaration of function 'PROTECr' is invalid in C99

so apparently it's been treating this as an implicit declaration all this time. This came up because attempts to install this gem with more recent versions of gem failed; I suspect somewhere along the way ruby (in mkmf, presumably?) has started building Makefiles with `-Wimplicit-function-declaration`, which all in all is a good thing.

Other changes beside this one are just automatic whitespace cleanup.