### PR TITLE
Fix handling of --with-R-dir on install

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -31,7 +31,7 @@ end
 File.open("r_config.h", "w") do |f|
   f.puts("#ifndef R_CONFIG_H")
   f.puts("#define R_CONFIG_H")
-  r_home = $configure_args.has_key?('--with-R-dir') || `R RHOME`.chomp
+  r_home = $configure_args['--with-R-dir'] || `R RHOME | grep -v ^WARNING:`.chomp
   f.puts("#define RSRUBY_R_HOME \"#{r_home}\"")
   f.puts("#endif")
 end


### PR DESCRIPTION
I've run into two problems here:

 * When --with-R-dir was passed, RSRUBY_R_HOME was being set to "true"
   rather than the path.

 * When falling back to using "R RHOME" with R_HOME set, R prints a
   warning to STDOUT (tsk...) which results in junk in RSRUBY_R_HOME.