### PR TITLE
Change call of SET_SYMVALUE to Rf_defineVar

### DIFF
--- a/ext/rsruby.c
+++ b/ext/rsruby.c
@@ -160,7 +160,7 @@ VALUE rr_init(VALUE self, VALUE r_argv){
   // * https://github.com/JuliaInterop/RCall.jl/pull/564
   // * https://stackoverflow.com/a/26354878/9086755
   // * https://cran.r-project.org/doc/manuals/r-release/R-exts.html (for R version 4.5.1)
-  Rf_defineVar(install("R.References"), R_References, _R_GlobalEnv);
+  Rf_defineVar(install("R.References"), R_References, R_GlobalEnv);
 
   for (i = 0; i < argc; i++)
     free(argv[i]);

--- a/ext/rsruby.c
+++ b/ext/rsruby.c
@@ -154,7 +154,8 @@ VALUE rr_init(VALUE self, VALUE r_argv){
 
   // Initialize the list of protected objects
   R_References = R_NilValue;
-  SET_SYMVALUE(install("R.References"), R_References);
+  // SET_SYMVALUE(install("R.References"), R_References);
+  Rf_defineVar(install("R.References"), R_References);
 
   for (i = 0; i < argc; i++)
     free(argv[i]);

--- a/ext/rsruby.c
+++ b/ext/rsruby.c
@@ -154,8 +154,13 @@ VALUE rr_init(VALUE self, VALUE r_argv){
 
   // Initialize the list of protected objects
   R_References = R_NilValue;
-  // SET_SYMVALUE(install("R.References"), R_References);
-  Rf_defineVar(install("R.References"), R_References);
+
+  // Was: SET_SYMVALUE(install("R.References"), R_References);
+  // See also:
+  // * https://github.com/JuliaInterop/RCall.jl/pull/564
+  // * https://stackoverflow.com/a/26354878/9086755
+  // * https://cran.r-project.org/doc/manuals/r-release/R-exts.html (for R version 4.5.1)
+  Rf_defineVar(install("R.References"), R_References, _R_GlobalEnv);
 
   for (i = 0; i < argc; i++)
     free(argv[i]);

--- a/ext/rsruby.c
+++ b/ext/rsruby.c
@@ -155,7 +155,9 @@ VALUE rr_init(VALUE self, VALUE r_argv){
   // Initialize the list of protected objects
   R_References = R_NilValue;
 
+  // Changed call of SET_SYMVALUE To Rf_defineVar.
   // Was: SET_SYMVALUE(install("R.References"), R_References);
+  // "R 4.5 introduced...stricter internal vs. external API boundaries"
   // See also:
   // * https://github.com/JuliaInterop/RCall.jl/pull/564
   // * https://stackoverflow.com/a/26354878/9086755


### PR DESCRIPTION
* Gem install of rsruby with a current version of R failed with error "implicit declaration of function SET_SYMVALUE".
* Research indicates this function is no longer available to the rsruby extension due to "stricter internal vs. external API boundaries".
* Replaced with Rf_defineVar function.
* See also comments in code.